### PR TITLE
Add "WebAssembly support in Magnum"

### DIFF
--- a/_posts/2017-08-28-WASM-support-in-magnum.md
+++ b/_posts/2017-08-28-WASM-support-in-magnum.md
@@ -1,0 +1,10 @@
+---
+title: "WebAssembly support in Magnum"
+urlex: "http://blog.magnum.graphics/announcements/webassembly-support-and-more/"
+author:
+  name: Jonathan Hale
+  url: "https://github.com/squareys"
+categories: [article]
+tags: [C/C++, Emscripten, WebAssembly, Magnum]
+excerpt: The Open Source C++11/C++14 and OpenGL graphics engine Magnum recently added first-class WebAssembly support. An article on the official blog explains how to easily compile your C++ projects to WebAssembly, compares it to asm.js and mentions a few useful tips for best online experience. Last but not least, there's a bunch of online demos that use both WebGL 1 and 2, showing how a single codebase can be run both natively and in the browser.
+---


### PR DESCRIPTION
Hi everyone,

[Magnum](https://github.com/mosra/magnum) recently added WebAssembly support and released an  [article about it](http://blog.magnum.graphics/announcements/webassembly-support-and-more/) on their website.

Cheers, Jonathan.